### PR TITLE
RRASTER PR #5473 followup

### DIFF
--- a/autotest/gdrivers/rraster.py
+++ b/autotest/gdrivers/rraster.py
@@ -61,7 +61,7 @@ def test_rraster_1_copy():
 
     filename = '/vsimem/rraster/byte_rraster.grd'
     gdal.Translate(filename, 'data/rraster/byte_rraster1.grd', format='RRASTER')
-#    assert not gdal.VSIStatL(filename + '.aux.xml'), 'did not expect .aux.xml'
+    assert not gdal.VSIStatL(filename + '.aux.xml'), 'did not expect .aux.xml'
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(26711)
     test_rraster_1(filename, check_prj=sr.ExportToWkt())
@@ -149,7 +149,7 @@ def test_rraster_rgba_copy():
         test_rraster_rgba(filename)
         gdal.GetDriverByName('RRASTER').Delete(filename)
 
-    
+
 ###############################################################################
 
 

--- a/frmts/raw/rrasterdataset.cpp
+++ b/frmts/raw/rrasterdataset.cpp
@@ -54,7 +54,7 @@ class RRASTERDataset final: public RawDataset
     bool        m_bGeoTransformValid = false;
     double      m_adfGeoTransform[6]{0,1,0,0,0,-1};
     VSILFILE   *m_fpImage = nullptr;
-    CPLString   m_osProjection{};
+    OGRSpatialReference m_oSRS{};
     std::shared_ptr<GDALRasterAttributeTable> m_poRAT{};
     std::shared_ptr<GDALColorTable> m_poCT{};
     bool        m_bNativeOrder = true;
@@ -95,14 +95,8 @@ class RRASTERDataset final: public RawDataset
 
     CPLErr GetGeoTransform( double * ) override;
     CPLErr SetGeoTransform( double *padfGeoTransform ) override;
-    const char *_GetProjectionRef() override;
-    CPLErr _SetProjection( const char *pszSRS ) override;
-    const OGRSpatialReference* GetSpatialRef() const override {
-        return GetSpatialRefFromOldGetProjectionRef();
-    }
-    CPLErr SetSpatialRef(const OGRSpatialReference* poSRS) override {
-        return OldSetProjectionFromSetSpatialRef(poSRS);
-    }
+    const OGRSpatialReference* GetSpatialRef() const override;
+    CPLErr SetSpatialRef(const OGRSpatialReference* poSRS) override;
 
     CPLErr      SetMetadata( char ** papszMetadata,
                                      const char * pszDomain = "" ) override;
@@ -477,6 +471,7 @@ CPLErr RRASTERRasterBand::IRasterIO( GDALRWFlag eRWFlag,
 
 RRASTERDataset::RRASTERDataset()
 {
+    m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 }
 
 /************************************************************************/
@@ -546,39 +541,6 @@ void RRASTERDataset::RewriteHeader()
         VSIFPrintfL(fp, "creator=%s\n", m_osCreator.c_str());
     if( !m_osCreated.empty() )
         VSIFPrintfL(fp, "created=%s\n", m_osCreated.c_str());
-
-    VSIFPrintfL(fp, "[georeference]\n");
-    VSIFPrintfL(fp, "nrows=%d\n", nRasterYSize);
-    VSIFPrintfL(fp, "ncols=%d\n", nRasterXSize);
-
-    VSIFPrintfL(fp, "xmin=%.18g\n", m_adfGeoTransform[0]);
-    VSIFPrintfL(fp, "ymin=%.18g\n",
-            m_adfGeoTransform[3] + nRasterYSize * m_adfGeoTransform[5]);
-    VSIFPrintfL(fp, "xmax=%.18g\n",
-            m_adfGeoTransform[0] + nRasterXSize * m_adfGeoTransform[1]);
-    VSIFPrintfL(fp, "ymax=%.18g\n", m_adfGeoTransform[3]);
-
-    if( !m_osProjection.empty() )
-    {
-        OGRSpatialReference oSRS;
-        oSRS.SetFromUserInput(m_osProjection, OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get());
-        char* pszProj4 = nullptr;
-        oSRS.exportToProj4(&pszProj4);
-        if( pszProj4 )
-        {
-            VSIFPrintfL(fp, "projection=%s\n", pszProj4);
-            VSIFree(pszProj4);
-        }
-        char* pszWKT = nullptr;
-//        const char* const apszOptions[] = { "FORMAT=WKT2_2019", nullptr };
-//        oSRS.exportToWkt(&pszWKT, apszOptions);
-        oSRS.exportToWkt(&pszWKT);
-        if( pszWKT )
-        {
-            VSIFPrintfL(fp, "wkt=%s\n", pszWKT);
-            VSIFree(pszWKT);
-        }
-    }
 
     VSIFPrintfL(fp, "[data]\n");
     GDALDataType eDT = GetRasterBand(1)->GetRasterDataType();
@@ -815,6 +777,39 @@ void RRASTERDataset::RewriteHeader()
         VSIFPrintfL(fp, "layername=%s\n", osLayerName.c_str());
     }
 
+    // Put the [georeference] section at end. Otherwise the wkt= entry
+    // could cause GDAL < 3.5 to be unable to open the file due to the
+    // Identify() function not using enough bytes
+    VSIFPrintfL(fp, "[georeference]\n");
+    VSIFPrintfL(fp, "nrows=%d\n", nRasterYSize);
+    VSIFPrintfL(fp, "ncols=%d\n", nRasterXSize);
+
+    VSIFPrintfL(fp, "xmin=%.18g\n", m_adfGeoTransform[0]);
+    VSIFPrintfL(fp, "ymin=%.18g\n",
+            m_adfGeoTransform[3] + nRasterYSize * m_adfGeoTransform[5]);
+    VSIFPrintfL(fp, "xmax=%.18g\n",
+            m_adfGeoTransform[0] + nRasterXSize * m_adfGeoTransform[1]);
+    VSIFPrintfL(fp, "ymax=%.18g\n", m_adfGeoTransform[3]);
+
+    if( !m_oSRS.IsEmpty() )
+    {
+        char* pszProj4 = nullptr;
+        m_oSRS.exportToProj4(&pszProj4);
+        if( pszProj4 )
+        {
+            VSIFPrintfL(fp, "projection=%s\n", pszProj4);
+            VSIFree(pszProj4);
+        }
+        char* pszWKT = nullptr;
+        const char* const apszOptions[] = { "FORMAT=WKT2_2019", nullptr };
+        m_oSRS.exportToWkt(&pszWKT, apszOptions);
+        if( pszWKT )
+        {
+            VSIFPrintfL(fp, "wkt=%s\n", pszWKT);
+            VSIFree(pszWKT);
+        }
+    }
+
     VSIFCloseL(fp);
 }
 
@@ -877,20 +872,19 @@ CPLErr RRASTERDataset::SetGeoTransform( double *padfGeoTransform )
 }
 
 /************************************************************************/
-/*                           GetProjectionRef()                         */
+/*                           GetSpatialRef()                            */
 /************************************************************************/
 
-const char * RRASTERDataset::_GetProjectionRef()
+const OGRSpatialReference* RRASTERDataset::GetSpatialRef() const
 {
-    return m_osProjection.c_str();
+    return m_oSRS.IsEmpty() ? nullptr : &m_oSRS;
 }
 
 /************************************************************************/
-/*                           SetProjection()                            */
+/*                           SetSpatialRef()                            */
 /************************************************************************/
 
-CPLErr RRASTERDataset::_SetProjection( const char *pszSRS )
-
+CPLErr RRASTERDataset::SetSpatialRef(const OGRSpatialReference* poSRS)
 {
     if( GetAccess() != GA_Update )
     {
@@ -899,7 +893,9 @@ CPLErr RRASTERDataset::_SetProjection( const char *pszSRS )
         return CE_Failure;
     }
 
-    m_osProjection = pszSRS ? pszSRS : "";
+    m_oSRS.Clear();
+    if( poSRS )
+        m_oSRS = *poSRS;
     SetHeaderDirty();
 
     return CE_None;
@@ -954,8 +950,16 @@ int RRASTERDataset::Identify( GDALOpenInfo * poOpenInfo )
 {
     if( poOpenInfo->nHeaderBytes < 40
         || poOpenInfo->fpL == nullptr
-        || !EQUAL( CPLGetExtension(poOpenInfo->pszFilename), "grd" )
-        || strstr(reinterpret_cast<const char *>(poOpenInfo->pabyHeader), "ncols") == nullptr
+        || !EQUAL( CPLGetExtension(poOpenInfo->pszFilename), "grd" ) )
+    {
+        return FALSE;
+    }
+
+    // We need to ingest enough bytes as the wkt= entry can be quite large
+    if( poOpenInfo->nHeaderBytes <= 1024 )
+        poOpenInfo->TryToIngest(4096);
+
+    if( strstr(reinterpret_cast<const char *>(poOpenInfo->pabyHeader), "ncols") == nullptr
         || strstr(reinterpret_cast<const char *>(poOpenInfo->pabyHeader), "nrows") == nullptr
         || strstr(reinterpret_cast<const char *>(poOpenInfo->pabyHeader), "xmin") == nullptr
         || strstr(reinterpret_cast<const char *>(poOpenInfo->pabyHeader), "ymin") == nullptr
@@ -1265,32 +1269,12 @@ GDALDataset *RRASTERDataset::Open( GDALOpenInfo * poOpenInfo )
     {
         if( !osProjection.empty() )
         {
-            OGRSpatialReference oSRS;
-            if( oSRS.importFromProj4( osProjection.c_str() ) == OGRERR_NONE )
-            {
-                char* pszWKT = nullptr;
-                const char* const apszOptions[] = { "FORMAT=WKT2_2019", nullptr };
-                oSRS.exportToWkt(&pszWKT, apszOptions);
-//                oSRS.exportToWkt( &pszWKT );
-                if( pszWKT )
-                    poDS->m_osProjection = pszWKT;
-                CPLFree( pszWKT );
-            }
+            poDS->m_oSRS.importFromProj4( osProjection.c_str() );
         }
-    } 
+    }
     else
     {
-        OGRSpatialReference oSRS;
-        if( oSRS.importFromWkt( osWkt.c_str() ) == OGRERR_NONE )
-        {
-            char* pszWKT = nullptr;
-            const char* const apszOptions[] = { "FORMAT=WKT2_2019", nullptr };
-            oSRS.exportToWkt(&pszWKT, apszOptions);
-//            oSRS.exportToWkt( &pszWKT );
-            if( pszWKT )
-                poDS->m_osProjection = pszWKT;
-            CPLFree( pszWKT );
-        }
+        poDS->m_oSRS.importFromWkt( osWkt.c_str() );
     }
 
     if( !osCreator.empty() )


### PR DESCRIPTION
- Use modern way of getting/setting SRS that avoid useless lossy
  roundtrips through WKT1
- Robustify Identify() method to read more bytes, in case a large wkt=
  entry is before the [data] section
- Move the [georeference] section at the end of the .grd file, so that
  the RRASTER driver of GDAL < 3.5 can read newer files
